### PR TITLE
Simplified API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(${PROJECT_NAME}
     src/l2encdec.cpp
     src/blowfish.cpp
     src/rsa.cpp
+    src/utils.cpp
     src/xor_utils.cpp
     src/zlib_utils.cpp
 )

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,8 +28,8 @@ std::vector<unsigned char> input;
 std::string filename = "";
 int protocol_version = 121;
 
-l2encdec::Params params;
-l2encdec::init_params(&params, protocol_version, filename);
+l2encdec::Params params{};
+l2encdec::init_params(params, protocol_version, filename);
 std::vector<unsigned char> output;
 l2encdec::decode(input, output, params);
 // or
@@ -69,7 +69,7 @@ struct Params {
 ---
 
 ```cpp
-bool init_params(Params* params, int protocol, std::string filename = "", bool use_legacy_decrypt_rsa = false);
+bool init_params(Params &params, int protocol, std::string filename = "", bool use_legacy_decrypt_rsa = false);
 ```
 
 Initialize default parameters for the specified protocol.

--- a/examples/cli/src/cli.cpp
+++ b/examples/cli/src/cli.cpp
@@ -364,7 +364,7 @@ int main(int argc, char *argv[])
                           : read_protocol_from_input_file_name(input_file_name))
                    : protocol;
 
-    l2encdec::Params params;
+    l2encdec::Params params{};
     if (protocol != 0 && !l2encdec::init_params(params, protocol, input_file_name, use_legacy_decrypt_rsa))
         std::cerr << "Warning: unsupported protocol" << std::endl;
 

--- a/examples/cli/src/cli.cpp
+++ b/examples/cli/src/cli.cpp
@@ -365,7 +365,7 @@ int main(int argc, char *argv[])
                    : protocol;
 
     l2encdec::Params params;
-    if (protocol != 0 && !l2encdec::init_params(&params, protocol, input_file_name, use_legacy_decrypt_rsa))
+    if (protocol != 0 && !l2encdec::init_params(params, protocol, input_file_name, use_legacy_decrypt_rsa))
         std::cerr << "Warning: unsupported protocol" << std::endl;
 
     params.skip_tail = skip_tail;

--- a/examples/txt211json/src/main.cpp
+++ b/examples/txt211json/src/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv)
         auto encrypted_meta_content = read_file(argv[2]);
 
         l2encdec::Params params;
-        if (!l2encdec::init_params(&params, L2_PROTOCOL_VERSION))
+        if (!l2encdec::init_params(params, L2_PROTOCOL_VERSION))
             throw std::runtime_error("Failed to initialize L2 protocol parameters");
 
         std::vector<unsigned char> main_content;

--- a/examples/txt211json/src/main.cpp
+++ b/examples/txt211json/src/main.cpp
@@ -36,16 +36,12 @@ int main(int argc, char **argv)
         auto encrypted_main_content = read_file(argv[1]);
         auto encrypted_meta_content = read_file(argv[2]);
 
-        l2encdec::Params params;
-        if (!l2encdec::init_params(params, L2_PROTOCOL_VERSION))
-            throw std::runtime_error("Failed to initialize L2 protocol parameters");
-
         std::vector<unsigned char> main_content;
-        if (l2encdec::decode(encrypted_main_content, main_content, params) != l2encdec::DecodeResult::SUCCESS)
+        if (l2encdec::decode(encrypted_main_content, main_content, L2_PROTOCOL_VERSION) != l2encdec::DecodeResult::SUCCESS)
             throw std::runtime_error("Failed to decode main file: " + std::string(argv[1]));
 
         std::vector<unsigned char> meta_content;
-        if (l2encdec::decode(encrypted_meta_content, meta_content, params) != l2encdec::DecodeResult::SUCCESS)
+        if (l2encdec::decode(encrypted_meta_content, meta_content, L2_PROTOCOL_VERSION) != l2encdec::DecodeResult::SUCCESS)
             throw std::runtime_error("Failed to decode meta file: " + std::string(argv[2]));
 
         auto normalized = normalize(

--- a/examples/txt211json/src/utf.h
+++ b/examples/txt211json/src/utf.h
@@ -16,4 +16,4 @@ class utf
     static constexpr size_t BYTES_PER_UTF16_CHAR = 2;
 };
 
-#endif
+#endif // UTF_H

--- a/examples/utx121webp/extern/UEViewer/src/ueviewer.cpp
+++ b/examples/utx121webp/extern/UEViewer/src/ueviewer.cpp
@@ -1,10 +1,12 @@
+// clang-format off
 #include <ueviewer.h>
-#include "Core.h"
+#include "Core.h" // IWYU pragma: keep
 #include "UnCore.h"
 #include "UnObject.h"
 #include "UnMaterial.h"
 #include "UnMaterial2.h"
 #include "UnPackage.h"
+// clang-format on
 
 static TextureData extract_texture_data(UTexture *texture)
 {

--- a/examples/utx121webp/src/main.cpp
+++ b/examples/utx121webp/src/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char **argv)
         std::vector<unsigned char> decoded_package;
         if (protocol != 0)
         {
-            if (l2encdec::decode_auto(encrypted_package, decoded_package, filename, protocol) != l2encdec::DecodeResult::SUCCESS)
+            if (l2encdec::decode_auto(encrypted_package, decoded_package, protocol, filename) != l2encdec::DecodeResult::SUCCESS)
                 throw std::runtime_error("Failed to decode package: " + std::string(argv[1]));
         }
         else

--- a/examples/utx121webp/src/main.cpp
+++ b/examples/utx121webp/src/main.cpp
@@ -161,11 +161,7 @@ int main(int argc, char **argv)
         std::vector<unsigned char> decoded_package;
         if (protocol != 0)
         {
-            l2encdec::Params params;
-            if (!l2encdec::init_params(&params, protocol, filename))
-                throw std::runtime_error("Failed to initialize L2 protocol parameters");
-
-            if (l2encdec::decode(encrypted_package, decoded_package, params) != l2encdec::DecodeResult::SUCCESS)
+            if (l2encdec::decode_auto(encrypted_package, decoded_package, filename, protocol) != l2encdec::DecodeResult::SUCCESS)
                 throw std::runtime_error("Failed to decode package: " + std::string(argv[1]));
         }
         else

--- a/examples/utx121webp/src/main.cpp
+++ b/examples/utx121webp/src/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char **argv)
         std::vector<unsigned char> decoded_package;
         if (protocol != 0)
         {
-            if (l2encdec::decode_auto(encrypted_package, decoded_package, protocol, filename) != l2encdec::DecodeResult::SUCCESS)
+            if (l2encdec::decode(encrypted_package, decoded_package, protocol, filename) != l2encdec::DecodeResult::SUCCESS)
                 throw std::runtime_error("Failed to decode package: " + std::string(argv[1]));
         }
         else

--- a/include/l2encdec.h
+++ b/include/l2encdec.h
@@ -91,59 +91,22 @@ L2ENCDEC_API DecodeResult decode(const std::vector<unsigned char> &input_data,
 /**
  * @brief Decode input data using automatic protocol detection.
  *
- * This function attempts to determine the correct Lineage 2 protocol
- * by inspecting the encrypted file header (unless @p skip_header is true).
- * If a protocol is explicitly provided via @p protocol, it is used instead.
- *
- * After determining the protocol, default parameters are initialized via
- * init_params(), and decode() is performed using those parameters.
- *
- * @param input        Raw encoded/encrypted file contents.
- * @param output       Buffer receiving the decoded/processed data.
- * @param filename     Used only for protocol 121 (XOR_FILENAME), ignored otherwise.
- * @param protocol     Optional override; if >0, this protocol is used directly.
- *                    If -1, protocol is extracted from the header or inferred.
- * @param skip_header  If true, header bytes are not read or stripped during decode.
- * @param skip_tail    If true, the footer checksum/tail is not removed.
- * @param use_legacy_rsa  If true, use legacy RSA parameters for 411–414.
- *
- * @return DecodeResult::SUCCESS on success, or an error code on failure.
  */
 L2ENCDEC_API DecodeResult decode_auto(
     const std::vector<unsigned char> &input,
     std::vector<unsigned char> &output,
     const std::string &filename, // only needed for protocol 121
     int protocol = -1,
-    bool skip_header = false,
-    bool skip_tail = false,
     bool use_legacy_rsa = false);
 
 /**
  * @brief Encode input data using automatic parameter initialization.
- *
- * This function initializes a parameter set for the specified protocol using
- * init_params(), applies optional header/tail suppression, and performs encode().
- *
- * Protocol must be explicitly provided for encoding, unlike decode_auto(),
- * because the intended output format cannot be inferred from the input.
- *
- * @param input        Raw data to encode/encrypt.
- * @param output       Buffer receiving the encoded/encrypted data.
- * @param filename     Used only for protocol 121 (XOR_FILENAME), ignored otherwise.
- * @param protocol     Protocol number (e.g. 111, 211, 413). Must be valid.
- * @param skip_header  If true, the header prefix is not prepended.
- * @param skip_tail    If true, the footer checksum/tail is not appended.
- * @param use_legacy_rsa  If true, use legacy RSA parameters for 411–414.
- *
- * @return EncodeResult::SUCCESS on success, or an error code on failure.
  */
 L2ENCDEC_API EncodeResult encode_auto(
     const std::vector<unsigned char> &input,
     std::vector<unsigned char> &output,
     const std::string &filename, // only used for protocol 121
     int protocol,
-    bool skip_header = false,
-    bool skip_tail = false,
     bool use_legacy_rsa = false);
 } // namespace l2encdec
 

--- a/include/l2encdec.h
+++ b/include/l2encdec.h
@@ -94,7 +94,7 @@ L2ENCDEC_API DecodeResult decode(const std::vector<unsigned char> &input_data,
  */
 L2ENCDEC_API DecodeResult decode_auto(const std::vector<unsigned char> &input,
                                       std::vector<unsigned char> &output,
-                                      int protocol = -1,
+                                      int protocol,
                                       const std::string &filename = "", // only needed for protocol 121
                                       bool use_legacy_rsa = false);
 

--- a/include/l2encdec.h
+++ b/include/l2encdec.h
@@ -89,8 +89,7 @@ L2ENCDEC_API DecodeResult decode(const std::vector<unsigned char> &input_data,
                                  const Params &params);
 
 /**
- * @brief Decode input data.
- *
+ * @brief Decode input data using protocol-derived parameters.
  */
 L2ENCDEC_API DecodeResult decode(const std::vector<unsigned char> &input,
                                  std::vector<unsigned char> &output,
@@ -99,7 +98,7 @@ L2ENCDEC_API DecodeResult decode(const std::vector<unsigned char> &input,
                                  bool use_legacy_rsa = false);
 
 /**
- * @brief Encode input data.
+ * @brief Encode input data using protocol-derived parameters.
  */
 L2ENCDEC_API EncodeResult encode(const std::vector<unsigned char> &input,
                                  std::vector<unsigned char> &output,

--- a/include/l2encdec.h
+++ b/include/l2encdec.h
@@ -89,7 +89,7 @@ L2ENCDEC_API DecodeResult decode(const std::vector<unsigned char> &input_data,
                                  const Params &params);
 
 /**
- * @brief Decode input data using automatic protocol detection.
+ * @brief Decode input data.
  *
  */
 L2ENCDEC_API DecodeResult decode_auto(const std::vector<unsigned char> &input,
@@ -99,7 +99,7 @@ L2ENCDEC_API DecodeResult decode_auto(const std::vector<unsigned char> &input,
                                       bool use_legacy_rsa = false);
 
 /**
- * @brief Encode input data using automatic parameter initialization.
+ * @brief Encode input data.
  */
 L2ENCDEC_API EncodeResult encode_auto(const std::vector<unsigned char> &input,
                                       std::vector<unsigned char> &output,

--- a/include/l2encdec.h
+++ b/include/l2encdec.h
@@ -48,7 +48,8 @@ struct Params
     Type type;
     std::string header;               // `decrypt`: expected header, `encrypt`: header to prepend
     std::string tail;                 // `encode`: custom tail
-    bool skip_tail;                   // `decrypt`: read file without tail; `encrypt`: do not append tail
+    bool skip_tail = false;           // `decrypt`: read file without tail; `encrypt`: do not append tail
+    bool skip_header = false;         // `decrypt`: ignore/prevent header handling; `encrypt`: do not prepend header
     std::string filename;             // for l2encdec::Type::XOR_FILENAME
     int xor_key;                      // for l2encdec::Type::XOR
     int xor_start_position;           // for l2encdec::Type::XOR_POSITION
@@ -74,18 +75,76 @@ L2ENCDEC_API bool init_params(Params *params, int protocol, const std::string &f
 L2ENCDEC_API ChecksumResult verify_checksum(const std::vector<unsigned char> &input_data);
 
 /**
- * @brief Encode the input data using the specified protocol.
+ * @brief Encode the input data using params.
  */
 L2ENCDEC_API EncodeResult encode(const std::vector<unsigned char> &input_data,
                                  std::vector<unsigned char> &output_data,
                                  const Params &params);
 
 /**
- * @brief Decode the input data using the specified protocol.
+ * @brief Decode the input data using params.
  */
 L2ENCDEC_API DecodeResult decode(const std::vector<unsigned char> &input_data,
                                  std::vector<unsigned char> &output_data,
                                  const Params &params);
+
+/**
+ * @brief Decode input data using automatic protocol detection.
+ *
+ * This function attempts to determine the correct Lineage 2 protocol
+ * by inspecting the encrypted file header (unless @p skip_header is true).
+ * If a protocol is explicitly provided via @p protocol, it is used instead.
+ *
+ * After determining the protocol, default parameters are initialized via
+ * init_params(), and decode() is performed using those parameters.
+ *
+ * @param input        Raw encoded/encrypted file contents.
+ * @param output       Buffer receiving the decoded/processed data.
+ * @param filename     Used only for protocol 121 (XOR_FILENAME), ignored otherwise.
+ * @param protocol     Optional override; if >0, this protocol is used directly.
+ *                    If -1, protocol is extracted from the header or inferred.
+ * @param skip_header  If true, header bytes are not read or stripped during decode.
+ * @param skip_tail    If true, the footer checksum/tail is not removed.
+ * @param use_legacy_rsa  If true, use legacy RSA parameters for 411–414.
+ *
+ * @return DecodeResult::SUCCESS on success, or an error code on failure.
+ */
+L2ENCDEC_API DecodeResult decode_auto(
+    const std::vector<unsigned char> &input,
+    std::vector<unsigned char> &output,
+    const std::string &filename, // only needed for protocol 121
+    int protocol = -1,
+    bool skip_header = false,
+    bool skip_tail = false,
+    bool use_legacy_rsa = false);
+
+/**
+ * @brief Encode input data using automatic parameter initialization.
+ *
+ * This function initializes a parameter set for the specified protocol using
+ * init_params(), applies optional header/tail suppression, and performs encode().
+ *
+ * Protocol must be explicitly provided for encoding, unlike decode_auto(),
+ * because the intended output format cannot be inferred from the input.
+ *
+ * @param input        Raw data to encode/encrypt.
+ * @param output       Buffer receiving the encoded/encrypted data.
+ * @param filename     Used only for protocol 121 (XOR_FILENAME), ignored otherwise.
+ * @param protocol     Protocol number (e.g. 111, 211, 413). Must be valid.
+ * @param skip_header  If true, the header prefix is not prepended.
+ * @param skip_tail    If true, the footer checksum/tail is not appended.
+ * @param use_legacy_rsa  If true, use legacy RSA parameters for 411–414.
+ *
+ * @return EncodeResult::SUCCESS on success, or an error code on failure.
+ */
+L2ENCDEC_API EncodeResult encode_auto(
+    const std::vector<unsigned char> &input,
+    std::vector<unsigned char> &output,
+    const std::string &filename, // only used for protocol 121
+    int protocol,
+    bool skip_header,
+    bool skip_tail,
+    bool use_legacy_rsa);
 } // namespace l2encdec
 
 #endif // L2ENCDEC_PUBLIC_H

--- a/include/l2encdec.h
+++ b/include/l2encdec.h
@@ -142,9 +142,9 @@ L2ENCDEC_API EncodeResult encode_auto(
     std::vector<unsigned char> &output,
     const std::string &filename, // only used for protocol 121
     int protocol,
-    bool skip_header,
-    bool skip_tail,
-    bool use_legacy_rsa);
+    bool skip_header = false,
+    bool skip_tail = false,
+    bool use_legacy_rsa = false);
 } // namespace l2encdec
 
 #endif // L2ENCDEC_PUBLIC_H

--- a/include/l2encdec.h
+++ b/include/l2encdec.h
@@ -94,8 +94,8 @@ L2ENCDEC_API DecodeResult decode(const std::vector<unsigned char> &input_data,
  */
 L2ENCDEC_API DecodeResult decode_auto(const std::vector<unsigned char> &input,
                                       std::vector<unsigned char> &output,
-                                      const std::string &filename, // only needed for protocol 121
                                       int protocol = -1,
+                                      const std::string &filename = "", // only needed for protocol 121
                                       bool use_legacy_rsa = false);
 
 /**
@@ -103,8 +103,8 @@ L2ENCDEC_API DecodeResult decode_auto(const std::vector<unsigned char> &input,
  */
 L2ENCDEC_API EncodeResult encode_auto(const std::vector<unsigned char> &input,
                                       std::vector<unsigned char> &output,
-                                      const std::string &filename, // only used for protocol 121
                                       int protocol,
+                                      const std::string &filename = "", // only used for protocol 121
                                       bool use_legacy_rsa = false);
 } // namespace l2encdec
 

--- a/include/l2encdec.h
+++ b/include/l2encdec.h
@@ -67,7 +67,7 @@ struct Params
  * @param use_legacy_decrypt_rsa Use original private exponent and modulus for decryption, for protocols 411-414
  * @return `true` if the parameters were initialized successfully, `false` otherwise.
  */
-L2ENCDEC_API bool init_params(Params *params, int protocol, const std::string &filename = "", bool use_legacy_decrypt_rsa = false);
+L2ENCDEC_API bool init_params(Params &params, int protocol, const std::string &filename = "", bool use_legacy_decrypt_rsa = false);
 
 /**
  * @brief Verify the checksum of the input data.
@@ -92,20 +92,20 @@ L2ENCDEC_API DecodeResult decode(const std::vector<unsigned char> &input_data,
  * @brief Decode input data.
  *
  */
-L2ENCDEC_API DecodeResult decode_auto(const std::vector<unsigned char> &input,
-                                      std::vector<unsigned char> &output,
-                                      int protocol,
-                                      const std::string &filename = "", // only needed for protocol 121
-                                      bool use_legacy_rsa = false);
+L2ENCDEC_API DecodeResult decode(const std::vector<unsigned char> &input,
+                                 std::vector<unsigned char> &output,
+                                 int protocol,
+                                 const std::string &filename = "", // only needed for protocol 121
+                                 bool use_legacy_rsa = false);
 
 /**
  * @brief Encode input data.
  */
-L2ENCDEC_API EncodeResult encode_auto(const std::vector<unsigned char> &input,
-                                      std::vector<unsigned char> &output,
-                                      int protocol,
-                                      const std::string &filename = "", // only used for protocol 121
-                                      bool use_legacy_rsa = false);
+L2ENCDEC_API EncodeResult encode(const std::vector<unsigned char> &input,
+                                 std::vector<unsigned char> &output,
+                                 int protocol,
+                                 const std::string &filename = "", // only used for protocol 121
+                                 bool use_legacy_rsa = false);
 } // namespace l2encdec
 
 #endif // L2ENCDEC_PUBLIC_H

--- a/include/l2encdec.h
+++ b/include/l2encdec.h
@@ -92,22 +92,20 @@ L2ENCDEC_API DecodeResult decode(const std::vector<unsigned char> &input_data,
  * @brief Decode input data using automatic protocol detection.
  *
  */
-L2ENCDEC_API DecodeResult decode_auto(
-    const std::vector<unsigned char> &input,
-    std::vector<unsigned char> &output,
-    const std::string &filename, // only needed for protocol 121
-    int protocol = -1,
-    bool use_legacy_rsa = false);
+L2ENCDEC_API DecodeResult decode_auto(const std::vector<unsigned char> &input,
+                                      std::vector<unsigned char> &output,
+                                      const std::string &filename, // only needed for protocol 121
+                                      int protocol = -1,
+                                      bool use_legacy_rsa = false);
 
 /**
  * @brief Encode input data using automatic parameter initialization.
  */
-L2ENCDEC_API EncodeResult encode_auto(
-    const std::vector<unsigned char> &input,
-    std::vector<unsigned char> &output,
-    const std::string &filename, // only used for protocol 121
-    int protocol,
-    bool use_legacy_rsa = false);
+L2ENCDEC_API EncodeResult encode_auto(const std::vector<unsigned char> &input,
+                                      std::vector<unsigned char> &output,
+                                      const std::string &filename, // only used for protocol 121
+                                      int protocol,
+                                      bool use_legacy_rsa = false);
 } // namespace l2encdec
 
 #endif // L2ENCDEC_PUBLIC_H

--- a/src/l2encdec.cpp
+++ b/src/l2encdec.cpp
@@ -257,8 +257,8 @@ L2ENCDEC_API l2encdec::DecodeResult l2encdec::decode(const std::vector<unsigned 
 L2ENCDEC_API l2encdec::EncodeResult l2encdec::encode_auto(
     const std::vector<unsigned char> &input,
     std::vector<unsigned char> &output,
-    const std::string &filename,
     int protocol,
+    const std::string &filename,
     bool use_legacy_rsa)
 {
     l2encdec::Params p{};
@@ -271,8 +271,8 @@ L2ENCDEC_API l2encdec::EncodeResult l2encdec::encode_auto(
 L2ENCDEC_API l2encdec::DecodeResult l2encdec::decode_auto(
     const std::vector<unsigned char> &input,
     std::vector<unsigned char> &output,
-    const std::string &filename,
     int protocol,
+    const std::string &filename,
     bool use_legacy_rsa)
 {
     if (input.size() >= HEADER_SIZE && protocol == -1)

--- a/src/l2encdec.cpp
+++ b/src/l2encdec.cpp
@@ -259,16 +259,11 @@ L2ENCDEC_API l2encdec::EncodeResult l2encdec::encode_auto(
     std::vector<unsigned char> &output,
     const std::string &filename,
     int protocol,
-    bool skip_header,
-    bool skip_tail,
     bool use_legacy_rsa)
 {
     l2encdec::Params p{};
     if (!l2encdec::init_params(&p, protocol, filename, use_legacy_rsa))
         return EncodeResult::INVALID_TYPE;
-
-    p.skip_header = skip_header;
-    p.skip_tail = skip_tail;
 
     return l2encdec::encode(input, output, p);
 }
@@ -278,11 +273,9 @@ L2ENCDEC_API l2encdec::DecodeResult l2encdec::decode_auto(
     std::vector<unsigned char> &output,
     const std::string &filename,
     int protocol,
-    bool skip_header,
-    bool skip_tail,
     bool use_legacy_rsa)
 {
-    if (!skip_header && input.size() >= HEADER_SIZE && protocol == -1)
+    if (input.size() >= HEADER_SIZE && protocol == -1)
     {
         std::string ascii;
         ascii.reserve(HEADER_PREFIX.size() + PROTOCOL_SIZE);
@@ -319,9 +312,6 @@ L2ENCDEC_API l2encdec::DecodeResult l2encdec::decode_auto(
         if (!found)
             return DecodeResult::INVALID_TYPE;
     }
-
-    p.skip_header = skip_header;
-    p.skip_tail = skip_tail;
 
     return decode(input, output, p);
 }

--- a/src/l2encdec.cpp
+++ b/src/l2encdec.cpp
@@ -1,4 +1,3 @@
-#include "l2encdec.h"
 #include "blowfish.h"
 #include "l2encdec_private.h" // IWYU pragma: keep
 #include "rsa.h"

--- a/src/l2encdec.cpp
+++ b/src/l2encdec.cpp
@@ -6,6 +6,7 @@
 #include "zlib_utils.h"
 #include <cstddef>
 #include <cstring>
+#include <algorithm>
 
 constexpr size_t FOOTER_SIZE = 20;
 constexpr size_t FOOTER_CRC32_OFFSET = 12;

--- a/src/l2encdec.cpp
+++ b/src/l2encdec.cpp
@@ -32,7 +32,7 @@ const l2encdec::Params MODERN_RSA_PARAMS = {
 };
 
 L2ENCDEC_API bool l2encdec::init_params(
-    Params *params, int protocol,
+    Params &params, int protocol,
     const std::string &filename,
     bool use_legacy_rsa)
 {
@@ -43,13 +43,13 @@ L2ENCDEC_API bool l2encdec::init_params(
     if (it == PROTOCOL_CONFIGS.end())
         return false;
 
-    *params = it->second;
+    params = it->second;
 
-    if (params->type == Type::RSA && !use_legacy_rsa)
-        *params = MODERN_RSA_PARAMS;
+    if (params.type == Type::RSA && !use_legacy_rsa)
+        params = MODERN_RSA_PARAMS;
 
-    params->filename = filename;
-    params->header = std::string(HEADER_PREFIX) + std::to_string(protocol);
+    params.filename = filename;
+    params.header = std::string(HEADER_PREFIX) + std::to_string(protocol);
 
     return true;
 }
@@ -156,7 +156,7 @@ L2ENCDEC_API l2encdec::DecodeResult l2encdec::decode(
     return DecodeResult::SUCCESS;
 }
 
-L2ENCDEC_API l2encdec::EncodeResult l2encdec::encode_auto(
+L2ENCDEC_API l2encdec::EncodeResult l2encdec::encode(
     const std::vector<unsigned char> &input,
     std::vector<unsigned char> &output,
     int protocol,
@@ -164,13 +164,13 @@ L2ENCDEC_API l2encdec::EncodeResult l2encdec::encode_auto(
     bool use_legacy_rsa)
 {
     l2encdec::Params p{};
-    if (!l2encdec::init_params(&p, protocol, filename, use_legacy_rsa))
+    if (!l2encdec::init_params(p, protocol, filename, use_legacy_rsa))
         return EncodeResult::INVALID_TYPE;
 
     return l2encdec::encode(input, output, p);
 }
 
-L2ENCDEC_API l2encdec::DecodeResult l2encdec::decode_auto(
+L2ENCDEC_API l2encdec::DecodeResult l2encdec::decode(
     const std::vector<unsigned char> &input,
     std::vector<unsigned char> &output,
     int protocol,
@@ -178,7 +178,7 @@ L2ENCDEC_API l2encdec::DecodeResult l2encdec::decode_auto(
     bool use_legacy_rsa)
 {
     l2encdec::Params p{};
-    if (!l2encdec::init_params(&p, protocol, filename, use_legacy_rsa))
+    if (!l2encdec::init_params(p, protocol, filename, use_legacy_rsa))
         return DecodeResult::INVALID_TYPE;
 
     return l2encdec::decode(input, output, p);

--- a/src/l2encdec.cpp
+++ b/src/l2encdec.cpp
@@ -3,7 +3,6 @@
 #include "rsa.h"
 #include "xor_utils.h"
 #include "zlib_utils.h"
-#include <algorithm>
 #include <cstddef>
 #include <cstring>
 
@@ -73,60 +72,6 @@ inline void insert_tail(std::vector<unsigned char> &data, std::string_view tail)
     }
 }
 
-// TODO: remove
-inline int get_protocol_from_params(const l2encdec::Params &p)
-{
-    if (!p.header.empty() &&
-        p.header.size() >= HEADER_PREFIX.size() + PROTOCOL_SIZE)
-    {
-        std::string digits =
-            p.header.substr(p.header.size() - PROTOCOL_SIZE, PROTOCOL_SIZE);
-
-        if (std::all_of(digits.begin(), digits.end(), ::isdigit))
-            return std::stoi(digits);
-    }
-
-    for (const auto &kv : PROTOCOL_CONFIGS)
-    {
-        int proto = kv.first;
-        const l2encdec::Params &cfg = kv.second;
-
-        if (p.type != cfg.type)
-            continue;
-
-        switch (p.type)
-        {
-        case l2encdec::Type::XOR:
-            if (p.xor_key == cfg.xor_key)
-                return proto;
-            break;
-
-        case l2encdec::Type::XOR_POSITION:
-            if (p.xor_start_position == cfg.xor_start_position)
-                return proto;
-            break;
-
-        case l2encdec::Type::XOR_FILENAME:
-            return proto;
-
-        case l2encdec::Type::BLOWFISH:
-            if (p.blowfish_key == cfg.blowfish_key)
-                return proto;
-            break;
-
-        case l2encdec::Type::RSA:
-            if (p.rsa_modulus == cfg.rsa_modulus)
-                return proto;
-            break;
-
-        default:
-            break;
-        }
-    }
-
-    return -1;
-}
-
 L2ENCDEC_API bool l2encdec::init_params(Params *params, int protocol, const std::string &filename, bool use_legacy_rsa)
 {
     if (protocol == 121 && filename.empty())
@@ -186,18 +131,7 @@ L2ENCDEC_API l2encdec::EncodeResult l2encdec::encode(const std::vector<unsigned 
     }
 
     if (!p.skip_header)
-    {
-        if (p.header.empty())
-        {
-            int protocol = get_protocol_from_params(p);
-            if (protocol == -1)
-                return EncodeResult::INVALID_TYPE;
-            std::string protocol_string = std::string(HEADER_PREFIX) + std::to_string(protocol);
-            insert_header(enc, protocol_string);
-        }
-        else
-            insert_header(enc, p.header);
-    }
+        insert_header(enc, p.header);
 
     if (!p.skip_tail)
     {
@@ -275,43 +209,9 @@ L2ENCDEC_API l2encdec::DecodeResult l2encdec::decode_auto(
     const std::string &filename,
     bool use_legacy_rsa)
 {
-    if (input.size() >= HEADER_SIZE && protocol == -1)
-    {
-        std::string ascii;
-        ascii.reserve(HEADER_PREFIX.size() + PROTOCOL_SIZE);
-
-        for (size_t i = 0; i < HEADER_SIZE; i += 2)
-            ascii.push_back(static_cast<char>(input[i]));
-
-        if (ascii.compare(0, HEADER_PREFIX.size(), HEADER_PREFIX) == 0)
-        {
-            std::string digits = ascii.substr(HEADER_PREFIX.size(), PROTOCOL_SIZE);
-            if (std::all_of(digits.begin(), digits.end(), ::isdigit))
-                protocol = std::stoi(digits);
-        }
-    }
-
     l2encdec::Params p{};
-    if (protocol > 0)
-    {
-        if (!l2encdec::init_params(&p, protocol, filename, use_legacy_rsa))
-            return DecodeResult::INVALID_TYPE;
-    }
-    else
-    {
-        bool found = false;
-        for (auto &kv : PROTOCOL_CONFIGS)
-        {
-            if (init_params(&p, kv.first, filename, use_legacy_rsa))
-            {
-                protocol = kv.first;
-                found = true;
-                break;
-            }
-        }
-        if (!found)
-            return DecodeResult::INVALID_TYPE;
-    }
+    if (!l2encdec::init_params(&p, protocol, filename, use_legacy_rsa))
+        return DecodeResult::INVALID_TYPE;
 
-    return decode(input, output, p);
+    return l2encdec::decode(input, output, p);
 }

--- a/src/l2encdec.cpp
+++ b/src/l2encdec.cpp
@@ -72,7 +72,10 @@ inline void insert_tail(std::vector<unsigned char> &data, std::string_view tail)
     }
 }
 
-L2ENCDEC_API bool l2encdec::init_params(Params *params, int protocol, const std::string &filename, bool use_legacy_rsa)
+L2ENCDEC_API bool l2encdec::init_params(
+    Params *params, int protocol,
+    const std::string &filename,
+    bool use_legacy_rsa)
 {
     if (protocol == 121 && filename.empty())
         return false;
@@ -100,7 +103,10 @@ L2ENCDEC_API l2encdec::ChecksumResult l2encdec::verify_checksum(const std::vecto
     return calc == checksum ? ChecksumResult::SUCCESS : ChecksumResult::MISMATCH;
 }
 
-L2ENCDEC_API l2encdec::EncodeResult l2encdec::encode(const std::vector<unsigned char> &input, std::vector<unsigned char> &output, const Params &p)
+L2ENCDEC_API l2encdec::EncodeResult l2encdec::encode(
+    const std::vector<unsigned char> &input,
+    std::vector<unsigned char> &output,
+    const Params &p)
 {
     std::vector<unsigned char> enc;
     switch (p.type)
@@ -145,7 +151,10 @@ L2ENCDEC_API l2encdec::EncodeResult l2encdec::encode(const std::vector<unsigned 
     return EncodeResult::SUCCESS;
 }
 
-L2ENCDEC_API l2encdec::DecodeResult l2encdec::decode(const std::vector<unsigned char> &input, std::vector<unsigned char> &output, const Params &p)
+L2ENCDEC_API l2encdec::DecodeResult l2encdec::decode(
+    const std::vector<unsigned char> &input,
+    std::vector<unsigned char> &output,
+    const Params &p)
 {
     size_t header_size = p.skip_header ? 0 : !p.header.empty() ? p.header.size() * 2
                                                                : HEADER_SIZE;

--- a/src/l2encdec.cpp
+++ b/src/l2encdec.cpp
@@ -4,9 +4,9 @@
 #include "rsa.h"
 #include "xor_utils.h"
 #include "zlib_utils.h"
+#include <algorithm>
 #include <cstddef>
 #include <cstring>
-#include <algorithm>
 
 constexpr size_t FOOTER_SIZE = 20;
 constexpr size_t FOOTER_CRC32_OFFSET = 12;
@@ -216,7 +216,7 @@ L2ENCDEC_API l2encdec::DecodeResult l2encdec::decode(const std::vector<unsigned 
 {
     size_t header_size = p.skip_header ? 0 : !p.header.empty() ? p.header.size() * 2
                                                                : HEADER_SIZE;
-    size_t footer_size = p.skip_tail ? 0 : !p.tail.empty() ? p.tail.size()
+    size_t footer_size = p.skip_tail ? 0 : !p.tail.empty() ? p.tail.size() / 2
                                                            : FOOTER_SIZE;
     if (input.size() < header_size + footer_size)
         return DecodeResult::DECRYPTION_FAILED;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,45 @@
+#include "utils.h"
+#include <cstring>
+#include <string>
+
+void utils::add_header(std::vector<unsigned char> &data, std::string_view header)
+{
+    const size_t wide_size = header.size() * 2;
+    data.reserve(data.size() + wide_size);
+
+    std::vector<unsigned char> wide;
+    wide.resize(wide_size);
+
+    for (size_t i = 0; i < header.size(); i++)
+    {
+        wide[i * 2] = static_cast<unsigned char>(header[i]);
+        wide[i * 2 + 1] = 0;
+    }
+
+    data.insert(data.begin(), wide.begin(), wide.end());
+}
+
+void utils::add_tail(std::vector<unsigned char> &data, uint32_t crc, size_t crc32_offset, size_t footer_size)
+{
+    const size_t start = data.size();
+    data.resize(start + footer_size);
+    unsigned char *footer = data.data() + start;
+    uint32_t *crc_ptr = reinterpret_cast<uint32_t *>(footer + crc32_offset);
+    std::memcpy(crc_ptr, &crc, sizeof(crc));
+}
+
+void utils::add_tail(std::vector<unsigned char> &data, std::string_view tail)
+{
+    std::string padded = std::string(tail);
+    if (padded.size() % 2 != 0)
+        padded.insert(padded.begin(), '0');
+
+    const size_t byte_count = padded.size() / 2;
+    data.reserve(data.size() + byte_count);
+
+    for (size_t i = 0; i < padded.size(); i += 2)
+    {
+        unsigned char value = static_cast<unsigned char>(std::stoi(padded.substr(i, 2), nullptr, 16));
+        data.push_back(value);
+    }
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,15 @@
+#ifndef UTILS_H
+#define UTILS_H
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+namespace utils
+{
+void add_header(std::vector<unsigned char> &data, std::string_view header);
+void add_tail(std::vector<unsigned char> &data, uint32_t crc, size_t crc32_offset, size_t footer_size);
+void add_tail(std::vector<unsigned char> &data, std::string_view tail);
+} // namespace utils
+
+#endif // UTILS_H


### PR DESCRIPTION
- [x] add `skip_header` option
- [x] extract utils from main file
- [x] add `encode`/`decode` overloads to simplify lib usage
- [x] fix bug in encode/decode when header is always expected to be provided in params
- [x] verify params in `decode`/`encode`
- [x] update docs
- [x] add tests